### PR TITLE
Support custom bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii 2 File Storage extension Change Log
 =======================================
 
+1.1.5, Under development
+-----------------------
+
+- Enh #24: Add support to set a custom name for a bucket (rhertogh)
+
+
 1.1.4, February 9, 2018
 -----------------------
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ return [
 ];
 ```
 
+You can specify a bucket name that is different from the internal name.
+In the following example the bucket is retrieved with `Wii::$app->fileStorage->getBucket('images');`
+but will be stored in the `my-image-bucket` bucket. 
+```php
+return [
+    'components' => [
+        'fileStorage' => [
+            'class' => 'yii2tech\filestorage\amazon\Storage',
+            'buckets' => [
+                'buckets' => [
+                    'images' => [
+                        'name' => 'my-image-bucket',
+                        'region' => 'us-west-1',
+                    ],
+                ],
+            ]
+        ],
+        // ...
+    ],
+    // ...
+];
+```
+
 You can also combine several different storages using [[\yii2tech\filestorage\hub\Storage]], if necessary:
 
 ```php

--- a/src/BaseStorage.php
+++ b/src/BaseStorage.php
@@ -117,7 +117,9 @@ abstract class BaseStorage extends Component implements StorageInterface
         if (is_object($bucketData)) {
             $bucketInstance = $bucketData;
         } else {
-            $bucketData['name'] = $bucketName;
+            if (!array_key_exists('name' , $bucketData)) {
+                $bucketData['name'] = $bucketName;
+            }
             $bucketInstance = $this->createBucketInstance($bucketData);
             $this->_buckets[$bucketName] = $bucketInstance;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

Add support to set a specific name for the bucket. E.g.:
```
'buckets' => [
    'images' => [
        'name' => 'my-image-bucket-on-aws',
        'region' => 'us-west-1',
    ],
],
```
In this case the bucket is called 'my-image-bucket-on-aws' in AWS but can be referenced as 'images' in the code.